### PR TITLE
enh: developer script to add a user with trivial password

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ sh ./create_databases.sh
 ```
 This creates the players and games sqlite dbs
 
+Optionally, you can then use the script `scripts/development/add_user.sh` to add users to the local players database with a password of "password".
+
+```
+./scripts/development/add_user.sh mylocalacct ./players.db
+# See scripts/development/add_user.sh comments for more options.
+```
+
 copy the properties and message to the target
 ```
 cp properties.xml ./target

--- a/scripts/development/add_user.sh
+++ b/scripts/development/add_user.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Script for developer purposes, generating SQL for creating a new user that can be authenticated
+# with the password of literally "password". (Therefore: only for development/test setup.)
+#
+# Usage:
+#
+#   add_user.sh <username>
+#
+# Examples:
+#
+#   add_user.sh localtestuser | sqlite3 playtakdb/players.db
+#
+#   for x in \$( seq 1 100 ) | do add_user.sh user$x | sqlite3 playtakdb/players.db
+#
+# Notes:
+#
+# 1. Only for use development purposes where the exact initial password doesn't matter!
+#
+# 2. Must start/restart server after new users have been added, since the server won't
+#    be aware of manually created users.
+#
+# 3. Why this script is useful: email isn't usually configured locally, so you cannot get the randomly created password.
+#    Also, this manual process would be laborious for a larger amount of test users or setting up a test bed.
+
+if [ -z $1 ]; then
+  echo "Error: Must provide username as first argument" 1>&2
+  echo "See script source for usage notes." 1>&2
+  exit 1
+fi
+
+# password hash = hash that authenticates to "password"
+# email is empty string
+sql="INSERT INTO players VALUES(1,'$1','\$2a\$10\$JpGWa00gDsDtJK0Ttq/dD.F2zTj9kCkdcHwO5pIZFfWbT3CfDY/C6','',1000.0,750.0,0,1000.0,0.0,0,0,0,'{}',0,0,0,0);"
+echo $sql

--- a/scripts/development/add_user.sh
+++ b/scripts/development/add_user.sh
@@ -5,13 +5,17 @@
 #
 # Usage:
 #
-#   add_user.sh <username>
+#   add_user.sh <username> <path-to-sqlite-db-file>
 #
 # Examples:
 #
-#   add_user.sh localtestuser | sqlite3 playtakdb/players.db
+#   add_user.sh localtestuser playtakdb/players.db
 #
-#   for x in \$( seq 1 100 ) | do add_user.sh user$x | sqlite3 playtakdb/players.db
+#   for x in \$( seq 1 100 ) | do add_user.sh user$x playtakdb/players.db
+#
+# Requirements:
+#
+#   expects sqlite3 to be executable in shell
 #
 # Notes:
 #
@@ -29,7 +33,27 @@ if [ -z $1 ]; then
   exit 1
 fi
 
-# password hash = hash that authenticates to "password"
-# email is empty string
-sql="INSERT INTO players VALUES(1,'$1','\$2a\$10\$JpGWa00gDsDtJK0Ttq/dD.F2zTj9kCkdcHwO5pIZFfWbT3CfDY/C6','',1000.0,750.0,0,1000.0,0.0,0,0,0,'{}',0,0,0,0);"
-echo $sql
+if [ -z $2 ]; then
+  echo "Error: Must provide database (as path to sqlite file) as second argument" 1>&2
+  echo "See script source for usage notes." 1>&2
+  exit 1
+fi
+
+existing=$( sqlite3 $2 "select COUNT(name) FROM players WHERE name='$1'" )
+
+if [ $existing != 0 ]; then
+  echo "User already exists with name $1"
+  echo "Exiting."
+  exit 1
+fi
+
+# Determining next player ID, since table doesn't currently autoinc with a default.
+nextId=$( sqlite3 $2 "select 1 + IFNULL(MAX(id), 0) FROM players" )
+echo "Using next Player ID: $nextId"
+
+# password hash below is a precalculated bcrypt hash that authenticates to "password"
+# email is empty string, which currently is allowed
+# id is determined earlier and provided explicitly
+sql="INSERT INTO players (id, name, password, email, rating, boost, ratedgames, maxrating, ratingage, ratingbase, unrated, isbot, fatigue, is_admin, is_mod, is_gagged, is_banned) VALUES('$nextId', '$1','\$2a\$10\$JpGWa00gDsDtJK0Ttq/dD.F2zTj9kCkdcHwO5pIZFfWbT3CfDY/C6','',1000.0,750.0,0,1000.0,0,0,0,0,'{}',0,0,0,0);"
+echo $sql | sqlite3 $2
+echo "Created user $1 (#$nextId) with password: password"


### PR DESCRIPTION
See source for justification, but for me this got around stumbles of having local users set up (so that I could test local tournament flow).